### PR TITLE
fixup for building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea/
 GitToolBox.jar
 testRun/
+.gradle/

--- a/GitToolBox/build.gradle
+++ b/GitToolBox/build.gradle
@@ -39,7 +39,7 @@ intellij {
     plugins 'git4idea'
     updateSinceUntilBuild false
     downloadSources true
-    plugins = ['Git4Idea', 'gr.jchrist.gitextender:0.4.1']
+    plugins = ['git4idea', 'gr.jchrist.gitextender:0.4.1']
 }
 
 apply plugin: 'idea'


### PR DESCRIPTION
I guess this plugin is developed under windows. In *nix systems paths are case sensitive and gradle do not find plugin on path Git4Idea, but on git4idea

I added to a ignore entry for .glade cache dir