### PR TITLE
Give the option to show author email/username

### DIFF
--- a/GitToolBox/src/main/java/zielu/gittoolbox/blame/calculator/BlameRevisionDataProvider.java
+++ b/GitToolBox/src/main/java/zielu/gittoolbox/blame/calculator/BlameRevisionDataProvider.java
@@ -3,11 +3,12 @@ package zielu.gittoolbox.blame.calculator;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vcs.history.VcsRevisionNumber;
 import com.intellij.openapi.vfs.VirtualFile;
-import java.util.Date;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import zielu.gittoolbox.revision.RevisionDataProvider;
+
+import java.util.Date;
+import java.util.List;
 
 class BlameRevisionDataProvider implements RevisionDataProvider {
   private final Project project;
@@ -37,6 +38,12 @@ class BlameRevisionDataProvider implements RevisionDataProvider {
   @Override
   public String getAuthor(int lineIndex) {
     return getLineCommit(lineIndex).getAuthorName();
+  }
+
+  @Nullable
+  @Override
+  public String getEmail(int lineIndex) {
+    return getLineCommit(lineIndex).getAuthorEmail();
   }
 
   @Nullable

--- a/GitToolBox/src/main/java/zielu/gittoolbox/blame/calculator/CommitInfo.java
+++ b/GitToolBox/src/main/java/zielu/gittoolbox/blame/calculator/CommitInfo.java
@@ -2,6 +2,7 @@ package zielu.gittoolbox.blame.calculator;
 
 import com.intellij.openapi.vcs.history.VcsRevisionNumber;
 import git4idea.GitRevisionNumber;
+
 import java.util.Date;
 import java.util.Objects;
 
@@ -10,6 +11,7 @@ class CommitInfo {
 
   private final VcsRevisionNumber revisionNumber;
   private String authorName;
+  private String authorEmail;
   private Date authorDate;
   private String summary;
 
@@ -23,6 +25,10 @@ class CommitInfo {
 
   void setAuthorName(String authorName) {
     this.authorName = authorName;
+  }
+
+  void setAuthorEmail(String authorEmail) {
+    this.authorEmail = authorEmail;
   }
 
   void setAuthorTime(long authorTime) {
@@ -39,6 +45,10 @@ class CommitInfo {
 
   String getAuthorName() {
     return authorName;
+  }
+
+  String getAuthorEmail() {
+    return authorEmail;
   }
 
   Date getAuthorDate() {

--- a/GitToolBox/src/main/java/zielu/gittoolbox/blame/calculator/IncrementalBlameBuilder.java
+++ b/GitToolBox/src/main/java/zielu/gittoolbox/blame/calculator/IncrementalBlameBuilder.java
@@ -4,6 +4,7 @@ import com.intellij.execution.process.ProcessOutputType;
 import com.intellij.openapi.util.Key;
 import git4idea.commands.GitLineHandlerListener;
 import git4idea.util.StringScanner;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -20,6 +21,7 @@ public class IncrementalBlameBuilder implements GitLineHandlerListener {
   private static final String FILENAME_TAG = "filename ";
   private static final String SUMMARY_TAG = "summary ";
   private static final String AUTHOR_TAG = "author ";
+  private static final String AUTHOR_EMAIL_TAG = "author-mail ";
   private static final String AUTHOR_TIME_TAG = "author-time ";
 
   private final Map<String, CommitInfo> commits = new HashMap<>();
@@ -90,6 +92,8 @@ public class IncrementalBlameBuilder implements GitLineHandlerListener {
       currentCommit.setAuthorName(line.substring(AUTHOR_TAG.length()).trim());
     } else if (line.startsWith(AUTHOR_TIME_TAG)) {
       currentCommit.setAuthorTime(Long.parseLong(line.substring(AUTHOR_TIME_TAG.length()).trim()));
+    } else if (line.startsWith(AUTHOR_EMAIL_TAG)) {
+      currentCommit.setAuthorEmail(line.substring(AUTHOR_EMAIL_TAG.length()).trim());
     }
   }
 

--- a/GitToolBox/src/main/java/zielu/gittoolbox/config/AuthorNameType.java
+++ b/GitToolBox/src/main/java/zielu/gittoolbox/config/AuthorNameType.java
@@ -4,25 +4,51 @@ import com.intellij.openapi.vcs.actions.ShortNameType;
 import com.intellij.util.xmlb.annotations.Transient;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.function.UnaryOperator;
+
 public enum AuthorNameType {
   INITIALS(ShortNameType.INITIALS),
   LASTNAME(ShortNameType.LASTNAME),
   FIRSTNAME(ShortNameType.FIRSTNAME),
-  FULL(ShortNameType.NONE);
+  FULL(ShortNameType.NONE),
+  EMAIL(email -> email, "Email"),
+  USERNAME(email -> {
+    if (email == null) {
+      return null;
+    }
+    int atIndex = email.indexOf('@');
+    return atIndex == -1 ? email : email.substring(0, atIndex);
+  }, "Username from Email");
 
   private final ShortNameType type;
+  private final UnaryOperator<String> shortener;
+  private final String description;
 
   AuthorNameType(ShortNameType type) {
     this.type = type;
+    this.description = null;
+    this.shortener = null;
+  }
+
+  AuthorNameType(UnaryOperator<String> shortener, String description) {
+    this.type = null;
+    this.shortener = shortener;
+    this.description = description;
   }
 
   @Transient
   public String getDescription() {
+    if (type == null) {
+      return description;
+    }
     return type.getDescription();
   }
 
   @Nullable
   public String shorten(@Nullable String author) {
+    if (type == null) {
+      return shortener.apply(author);
+    }
     return ShortNameType.shorten(author, type);
   }
 

--- a/GitToolBox/src/main/java/zielu/gittoolbox/revision/LightRevisionInfoFactory.java
+++ b/GitToolBox/src/main/java/zielu/gittoolbox/revision/LightRevisionInfoFactory.java
@@ -2,9 +2,10 @@ package zielu.gittoolbox.revision;
 
 import com.intellij.openapi.vcs.history.VcsFileRevision;
 import com.intellij.openapi.vfs.VirtualFile;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import zielu.gittoolbox.util.GtStringUtil;
+
+import java.util.Date;
 
 class LightRevisionInfoFactory implements RevisionInfoFactory {
   @NotNull
@@ -12,8 +13,9 @@ class LightRevisionInfoFactory implements RevisionInfoFactory {
   public RevisionInfo forLine(@NotNull RevisionDataProvider provider, int lineNumber) {
     Date lineDate = provider.getDate(lineNumber);
     String author = provider.getAuthor(lineNumber);
+    String email = provider.getEmail(lineNumber);
     String subject = provider.getSubject(lineNumber);
-    return new RevisionInfoImpl(provider.getRevisionNumber(lineNumber), author, lineDate, subject);
+    return new RevisionInfoImpl(provider.getRevisionNumber(lineNumber), author, email, lineDate, subject);
   }
 
   @NotNull
@@ -23,6 +25,6 @@ class LightRevisionInfoFactory implements RevisionInfoFactory {
     String author = revision.getAuthor();
     String commitMessage = revision.getCommitMessage();
     String subject = GtStringUtil.firstLine(commitMessage);
-    return new RevisionInfoImpl(revision.getRevisionNumber(), author, date, subject);
+    return new RevisionInfoImpl(revision.getRevisionNumber(), author, author, date, subject);
   }
 }

--- a/GitToolBox/src/main/java/zielu/gittoolbox/revision/RevisionDataProvider.java
+++ b/GitToolBox/src/main/java/zielu/gittoolbox/revision/RevisionDataProvider.java
@@ -3,9 +3,10 @@ package zielu.gittoolbox.revision;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vcs.history.VcsRevisionNumber;
 import com.intellij.openapi.vfs.VirtualFile;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Date;
 
 public interface RevisionDataProvider {
   @Nullable
@@ -13,6 +14,9 @@ public interface RevisionDataProvider {
 
   @Nullable
   String getAuthor(int lineIndex);
+
+  @Nullable
+  String getEmail(int lineIndex);
 
   @Nullable
   String getSubject(int lineIndex);

--- a/GitToolBox/src/main/java/zielu/gittoolbox/revision/RevisionInfo.java
+++ b/GitToolBox/src/main/java/zielu/gittoolbox/revision/RevisionInfo.java
@@ -1,9 +1,10 @@
 package zielu.gittoolbox.revision;
 
 import com.intellij.openapi.vcs.history.VcsRevisionNumber;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Date;
 
 public interface RevisionInfo {
   RevisionInfo EMPTY = new RevisionInfo() {
@@ -18,6 +19,12 @@ public interface RevisionInfo {
     @NotNull
     @Override
     public String getAuthor() {
+      return EMPTY_TEXT;
+    }
+
+    @NotNull
+    @Override
+    public String getEmail() {
       return EMPTY_TEXT;
     }
 
@@ -49,6 +56,9 @@ public interface RevisionInfo {
 
   @NotNull
   String getAuthor();
+
+  @NotNull
+  String getEmail();
 
   @NotNull
   Date getDate();

--- a/GitToolBox/src/main/java/zielu/gittoolbox/revision/RevisionInfoImpl.java
+++ b/GitToolBox/src/main/java/zielu/gittoolbox/revision/RevisionInfoImpl.java
@@ -1,20 +1,23 @@
 package zielu.gittoolbox.revision;
 
 import com.intellij.openapi.vcs.history.VcsRevisionNumber;
-import java.util.Date;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Date;
 
 final class RevisionInfoImpl implements RevisionInfo {
   private final VcsRevisionNumber revisionNumber;
   private final String author;
+  private final String email;
   private final Date date;
   private final String subject;
 
-  RevisionInfoImpl(@NotNull VcsRevisionNumber revisionNumber, String author, @Nullable Date revisionDate,
-                   String subject) {
+  RevisionInfoImpl(@NotNull VcsRevisionNumber revisionNumber, String author, String email,
+                   @Nullable Date revisionDate, String subject) {
     this.revisionNumber = revisionNumber;
     this.author = author != null ? prepareAuthor(author) : "EMPTY";
+    this.email = email != null ? prepareEmail(email) : "EMPTY";
     if (revisionDate != null) {
       date = revisionDate;
     } else {
@@ -29,6 +32,12 @@ final class RevisionInfoImpl implements RevisionInfo {
   }
 
   @NotNull
+  private String prepareEmail(@NotNull String email) {
+    email = email.trim();
+    return email.substring(1, email.length() - 1);
+  }
+
+  @NotNull
   @Override
   public VcsRevisionNumber getRevisionNumber() {
     return revisionNumber;
@@ -38,6 +47,12 @@ final class RevisionInfoImpl implements RevisionInfo {
   @Override
   public String getAuthor() {
     return author;
+  }
+
+  @NotNull
+  @Override
+  public String getEmail() {
+    return email;
   }
 
   @NotNull

--- a/GitToolBox/src/main/java/zielu/gittoolbox/ui/blame/BlamePresenterImpl.java
+++ b/GitToolBox/src/main/java/zielu/gittoolbox/ui/blame/BlamePresenterImpl.java
@@ -55,12 +55,15 @@ class BlamePresenterImpl implements BlamePresenter {
   @NotNull
   @Override
   public String getPopup(@NotNull RevisionInfo revisionInfo, @Nullable String details) {
-    StringBand text = new StringBand(11)
+    StringBand text = new StringBand(14)
         .append(COMMIT_PREFIX)
         .append(revisionInfo.getRevisionNumber().asString())
         .append("\n")
         .append(AUTHOR_PREFIX)
         .append(AuthorNameType.FULL.shorten(revisionInfo.getAuthor()))
+        .append(" &lt;")
+        .append(AuthorNameType.EMAIL.shorten(revisionInfo.getEmail()))
+        .append("&gt;")
         .append("\n")
         .append(DATE_PREFIX)
         .append(datePresenter.format(DateType.ABSOLUTE, revisionInfo.getDate()))

--- a/GitToolBox/src/main/java/zielu/gittoolbox/ui/blame/BlamePresenterImpl.java
+++ b/GitToolBox/src/main/java/zielu/gittoolbox/ui/blame/BlamePresenterImpl.java
@@ -1,7 +1,6 @@
 package zielu.gittoolbox.ui.blame;
 
 import com.intellij.openapi.util.text.StringUtil;
-import java.util.Date;
 import jodd.util.StringBand;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -12,6 +11,8 @@ import zielu.gittoolbox.config.DateType;
 import zielu.gittoolbox.config.GitToolBoxConfig2;
 import zielu.gittoolbox.revision.RevisionInfo;
 import zielu.gittoolbox.ui.DatePresenter;
+
+import java.util.Date;
 
 class BlamePresenterImpl implements BlamePresenter {
   private static final String SUBJECT_SEPARATOR = " " + UtfSeq.BULLET + " ";
@@ -29,7 +30,7 @@ class BlamePresenterImpl implements BlamePresenter {
   @Override
   public String getEditorInline(@NotNull RevisionInfo revisionInfo) {
     StringBand info = new StringBand(5)
-        .append(formatInlineAuthor(revisionInfo.getAuthor()))
+        .append(formatInlineAuthor(revisionInfo))
         .append(", ")
         .append(formatDate(revisionInfo.getDate()));
     boolean showSubject = GitToolBoxConfig2.getInstance().blameInlineShowSubject;
@@ -45,7 +46,7 @@ class BlamePresenterImpl implements BlamePresenter {
     return new StringBand(5)
         .append(ResBundle.message("blame.prefix"))
         .append(" ")
-        .append(formatStatusAuthor(revisionInfo.getAuthor()))
+        .append(formatStatusAuthor(revisionInfo))
         .append(" ")
         .append(datePresenter.format(DateType.ABSOLUTE, revisionInfo.getDate()))
         .toString();
@@ -70,12 +71,26 @@ class BlamePresenterImpl implements BlamePresenter {
     return text.toString();
   }
 
-  private String formatInlineAuthor(@Nullable String author) {
-    return GitToolBoxConfig2.getInstance().blameInlineAuthorNameType.shorten(author);
+  private String formatInlineAuthor(@NotNull RevisionInfo revisionInfo) {
+    AuthorNameType nameType = GitToolBoxConfig2.getInstance().blameInlineAuthorNameType;
+    switch (nameType) {
+      case EMAIL:
+      case USERNAME:
+        return nameType.shorten(revisionInfo.getEmail());
+      default:
+        return nameType.shorten(revisionInfo.getAuthor());
+    }
   }
 
-  private String formatStatusAuthor(@Nullable String author) {
-    return GitToolBoxConfig2.getInstance().blameStatusAuthorNameType.shorten(author);
+  private String formatStatusAuthor(@NotNull RevisionInfo revisionInfo) {
+    AuthorNameType nameType = GitToolBoxConfig2.getInstance().blameStatusAuthorNameType;
+    switch (nameType) {
+      case EMAIL:
+      case USERNAME:
+        return nameType.shorten(revisionInfo.getEmail());
+      default:
+        return nameType.shorten(revisionInfo.getAuthor());
+    }
   }
 
   private String formatDate(@Nullable Date date) {


### PR DESCRIPTION
This allows users to display the author’s name as their full email address or the username component of their email. The latter is particularly useful when everyone on a project has an email with the same domain.

This also adds the email address to the blame popup.

Unfortunately there’s no way I know of to get the email when provided with a `VcsFileRevision` so I just fallback to the author’s name. See `LightRevisionInfoFactory#forFile`. I’m not sure how often that method is called.